### PR TITLE
Weather totem classes are now extended from the abstract totem.

### DIFF
--- a/src/main/java/net/linkle/valley/Registry/WeaponsAndTools/Totems/AbstractTotemBase.java
+++ b/src/main/java/net/linkle/valley/Registry/WeaponsAndTools/Totems/AbstractTotemBase.java
@@ -1,0 +1,69 @@
+package net.linkle.valley.Registry.WeaponsAndTools.Totems;
+
+import net.minecraft.advancement.criterion.Criteria;
+import net.minecraft.entity.LivingEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.item.ItemUsage;
+import net.minecraft.item.Items;
+import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.server.world.ServerWorld;
+import net.minecraft.stat.Stats;
+import net.minecraft.util.Hand;
+import net.minecraft.util.TypedActionResult;
+import net.minecraft.util.UseAction;
+import net.minecraft.world.World;
+
+public abstract class AbstractTotemBase extends Item {
+    
+    public static final int MAX_DURATION = 24000;
+
+    public AbstractTotemBase(Settings settings) {
+        super(settings);
+    }
+    
+    @Override
+    public ItemStack finishUsing(ItemStack stack, World world, LivingEntity user) {
+        PlayerEntity playerEntity = user instanceof PlayerEntity ? (PlayerEntity)user : null;
+        if (playerEntity instanceof ServerPlayerEntity serverEntity) {
+            Criteria.CONSUME_ITEM.trigger(serverEntity, stack);
+        }
+
+        if (playerEntity != null) {
+            playerEntity.incrementStat(Stats.USED.getOrCreateStat(this));
+            if (!playerEntity.getAbilities().creativeMode) {
+                stack.decrement(1);
+            }
+        }
+
+        return stack.isEmpty() ? new ItemStack(Items.AIR, 0) : stack;
+    }
+    
+    @Override
+    public int getMaxUseTime(ItemStack stack) {
+        return 1;
+    }
+
+    @Override
+    public UseAction getUseAction(ItemStack stack) {
+        return UseAction.BLOCK;
+    }
+    
+    @Override
+    public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
+        if (!canSetWeather(world)) {
+            return TypedActionResult.pass(user.getStackInHand(hand));
+        }
+        
+        if (world instanceof ServerWorld serverWorld) {
+            setWeather(serverWorld);
+        }
+
+        return ItemUsage.consumeHeldItem(world, user, hand);
+    }
+    
+    public abstract boolean canSetWeather(World world);
+    
+    public abstract void setWeather(ServerWorld world);
+}

--- a/src/main/java/net/linkle/valley/Registry/WeaponsAndTools/Totems/RainTotemBase.java
+++ b/src/main/java/net/linkle/valley/Registry/WeaponsAndTools/Totems/RainTotemBase.java
@@ -1,55 +1,20 @@
 package net.linkle.valley.Registry.WeaponsAndTools.Totems;
 
-import net.minecraft.advancement.criterion.Criteria;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemUsage;
-import net.minecraft.item.Items;
-import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.stat.Stats;
-import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
-import net.minecraft.util.UseAction;
 import net.minecraft.world.World;
 
-public class RainTotemBase extends Item {
+public class RainTotemBase extends AbstractTotemBase {
     public RainTotemBase(Settings settings) {
         super(settings);
     }
 
-    public ItemStack finishUsing(ItemStack stack, World world, LivingEntity user) {
-        PlayerEntity playerEntity = user instanceof PlayerEntity ? (PlayerEntity)user : null;
-        if (playerEntity instanceof ServerPlayerEntity) {
-            Criteria.CONSUME_ITEM.trigger((ServerPlayerEntity)playerEntity, stack);
-        }
-
-        if (playerEntity != null) {
-            playerEntity.incrementStat(Stats.USED.getOrCreateStat(this));
-            if (!playerEntity.getAbilities().creativeMode) {
-                stack.decrement(1);
-            }
-        }
-
-        return stack.isEmpty() ? new ItemStack(Items.AIR, 0) : stack;
-    }
-
-    public int getMaxUseTime(ItemStack stack) {
-        return 1;
-    }
-
-    public UseAction getUseAction(ItemStack stack) {
-        return UseAction.BLOCK;
+    @Override
+    public boolean canSetWeather(World world) {
+        return !world.isRaining();
     }
 
     @Override
-    public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
-        if (!world.isClient) {
-            ((ServerWorld)world).setWeather(0, 24000, true, false);
-        }
-
-        return ItemUsage.consumeHeldItem(world, user, hand);
+    public void setWeather(ServerWorld world) {
+        world.setWeather(0, MAX_DURATION, true, false);
     }
 }

--- a/src/main/java/net/linkle/valley/Registry/WeaponsAndTools/Totems/StormTotemBase.java
+++ b/src/main/java/net/linkle/valley/Registry/WeaponsAndTools/Totems/StormTotemBase.java
@@ -1,55 +1,20 @@
 package net.linkle.valley.Registry.WeaponsAndTools.Totems;
 
-import net.minecraft.advancement.criterion.Criteria;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemUsage;
-import net.minecraft.item.Items;
-import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.stat.Stats;
-import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
-import net.minecraft.util.UseAction;
 import net.minecraft.world.World;
 
-public class StormTotemBase extends Item {
+public class StormTotemBase extends AbstractTotemBase {
     public StormTotemBase(Settings settings) {
         super(settings);
     }
 
-    public ItemStack finishUsing(ItemStack stack, World world, LivingEntity user) {
-        PlayerEntity playerEntity = user instanceof PlayerEntity ? (PlayerEntity)user : null;
-        if (playerEntity instanceof ServerPlayerEntity) {
-            Criteria.CONSUME_ITEM.trigger((ServerPlayerEntity)playerEntity, stack);
-        }
-
-        if (playerEntity != null) {
-            playerEntity.incrementStat(Stats.USED.getOrCreateStat(this));
-            if (!playerEntity.getAbilities().creativeMode) {
-                stack.decrement(1);
-            }
-        }
-
-        return stack.isEmpty() ? new ItemStack(Items.AIR, 0) : stack;
-    }
-
-    public int getMaxUseTime(ItemStack stack) {
-        return 1;
-    }
-
-    public UseAction getUseAction(ItemStack stack) {
-        return UseAction.BLOCK;
+    @Override
+    public boolean canSetWeather(World world) {
+        return !world.isThundering();
     }
 
     @Override
-    public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
-        if (!world.isClient) {
-            ((ServerWorld)world).setWeather(0, 24000, true, true);
-        }
-
-        return ItemUsage.consumeHeldItem(world, user, hand);
+    public void setWeather(ServerWorld world) {
+        world.setWeather(0, MAX_DURATION, true, true);
     }
 }

--- a/src/main/java/net/linkle/valley/Registry/WeaponsAndTools/Totems/SunshineTotemBase.java
+++ b/src/main/java/net/linkle/valley/Registry/WeaponsAndTools/Totems/SunshineTotemBase.java
@@ -1,55 +1,20 @@
 package net.linkle.valley.Registry.WeaponsAndTools.Totems;
 
-import net.minecraft.advancement.criterion.Criteria;
-import net.minecraft.entity.LivingEntity;
-import net.minecraft.entity.player.PlayerEntity;
-import net.minecraft.item.Item;
-import net.minecraft.item.ItemStack;
-import net.minecraft.item.ItemUsage;
-import net.minecraft.item.Items;
-import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;
-import net.minecraft.stat.Stats;
-import net.minecraft.util.Hand;
-import net.minecraft.util.TypedActionResult;
-import net.minecraft.util.UseAction;
 import net.minecraft.world.World;
 
-public class SunshineTotemBase extends Item {
+public class SunshineTotemBase extends AbstractTotemBase {
     public SunshineTotemBase(Settings settings) {
         super(settings);
     }
 
-    public ItemStack finishUsing(ItemStack stack, World world, LivingEntity user) {
-        PlayerEntity playerEntity = user instanceof PlayerEntity ? (PlayerEntity)user : null;
-        if (playerEntity instanceof ServerPlayerEntity) {
-            Criteria.CONSUME_ITEM.trigger((ServerPlayerEntity)playerEntity, stack);
-        }
-
-        if (playerEntity != null) {
-            playerEntity.incrementStat(Stats.USED.getOrCreateStat(this));
-            if (!playerEntity.getAbilities().creativeMode) {
-                stack.decrement(1);
-            }
-        }
-
-        return stack.isEmpty() ? new ItemStack(Items.AIR, 0) : stack;
-    }
-
-    public int getMaxUseTime(ItemStack stack) {
-        return 1;
-    }
-
-    public UseAction getUseAction(ItemStack stack) {
-        return UseAction.BLOCK;
+    @Override
+    public boolean canSetWeather(World world) {
+        return world.isRaining();
     }
 
     @Override
-    public TypedActionResult<ItemStack> use(World world, PlayerEntity user, Hand hand) {
-        if (!world.isClient) {
-            ((ServerWorld)world).setWeather(24000, 0, false, false);
-        }
-
-        return ItemUsage.consumeHeldItem(world, user, hand);
+    public void setWeather(ServerWorld world) {
+        world.setWeather(MAX_DURATION, 0, false, false);
     }
 }


### PR DESCRIPTION
Those totem classes look like they needed abstract class upon it. So I added the `AbstractTotemBase` abstract class for all weather totems. Plus, I added that it doesn't consume the totem if they don't make any changes to the weather.