### PR TITLE
Make Valleycraft items composable.

### DIFF
--- a/src/main/java/net/linkle/valley/Registry/Initializers/Compostables.java
+++ b/src/main/java/net/linkle/valley/Registry/Initializers/Compostables.java
@@ -1,0 +1,70 @@
+package net.linkle.valley.Registry.Initializers;
+
+import static net.linkle.valley.Registry.Mixin.CompostableItems.registerItem;
+
+/** Registering items for composer block */
+public class Compostables {
+    public static void initialize() {
+        float levelLow = 0.3f; // leaves, seeds, saplings, grass.
+        float levelMed = 0.5f; // double plant, vines.
+        float levelHigh = 0.65f; // foods, flowers.
+        float levelVery = 0.85f; // blocks.
+        float levelUltra = 1.0f; // specialties.
+
+        registerItem(levelLow, Blocks.RICE_SEEDLINGS);
+        registerItem(levelLow, Blocks.TOMATO_BUSH);
+        registerItem(levelLow, Blocks.SPICY_BERRY_BUSH);
+        registerItem(levelLow, Blocks.BITTER_BERRY_BUSH);
+        registerItem(levelLow, Blocks.HOLLY_BUSH);
+        registerItem(levelLow, Blocks.APPLE_SAPLING);
+        registerItem(levelLow, Blocks.APPLE_LEAVES);
+        registerItem(levelLow, Blocks.APPLE_LEAVES_EMPTY);
+        registerItem(levelLow, Blocks.SMALL_CACTUS);
+        registerItem(levelLow, Crops.PUFF_SEEDS);
+        registerItem(levelLow, Crops.MANDRAKE_SEEDS);
+        registerItem(levelLow, Crops.GREEN_BEAN);
+        registerItem(levelLow, Crops.GB_SEEDS);
+
+        registerItem(levelMed, Blocks.MOREL);
+        registerItem(levelMed, Blocks.BUSH);
+        registerItem(levelMed, Blocks.BUSH_ALIVE);
+        registerItem(levelMed, Blocks.BUSH_ALIVE_TALL);
+        registerItem(levelMed, Blocks.FERNBUSH);
+        registerItem(levelMed, Blocks.JUNGLE_CAP);
+        registerItem(levelMed, Blocks.ORANGE_FERN);
+        registerItem(levelMed, Blocks.SPROUT);
+        registerItem(levelMed, Blocks.MAIZE_CROP);
+        registerItem(levelMed, Blocks.REED_BLOCK);
+        registerItem(levelMed, Blocks.MINER_BUSH);
+        registerItem(levelMed, Blocks.ONION);
+        registerItem(levelMed, Blocks.MOSSY_VINE);
+        registerItem(levelMed, Blocks.SWAMP_BUSH);
+        registerItem(levelMed, Blocks.HEDGE);
+        registerItem(levelMed, Crops.MANDRAKE);
+
+        registerItem(levelHigh, Blocks.ROSEBUSH);
+        registerItem(levelHigh, Blocks.LILACBUSH);
+        registerItem(levelHigh, Blocks.PEONYBUSH);
+        registerItem(levelHigh, Blocks.FERNBUSH);
+        registerItem(levelHigh, Blocks.WEAPING_SWAMP_WILLOW);
+        registerItem(levelHigh, Blocks.REDWOOD_SORREL);
+        registerItem(levelHigh, Blocks.CROCUS);
+        registerItem(levelHigh, Blocks.DANDELION_PUFF);
+        registerItem(levelHigh, Blocks.LAVENDER);
+        registerItem(levelHigh, Blocks.LAVENDER_SPRIG);
+        registerItem(levelHigh, Blocks.SWAMP_RIBBON);
+        registerItem(levelHigh, Blocks.ROSE_SPRIG);
+        registerItem(levelHigh, Blocks.BLACK_DAHLIA);
+        registerItem(levelHigh, Blocks.ICE_ROSE);
+        registerItem(levelHigh, Blocks.WILD_CARROT);
+        registerItem(levelHigh, Blocks.WILD_POTATO);
+        registerItem(levelHigh, Blocks.WILD_BEET);
+        registerItem(levelHigh, Blocks.WILD_WHEAT);
+        registerItem(levelHigh, Blocks.ORANGE_BEAUTY);
+        registerItem(levelHigh, Blocks.JUNGLE_BUSH);
+        registerItem(levelHigh, Blocks.JUNGLE_BUSH);
+        registerItem(levelHigh, Crops.COOKED_MANDRAKE);
+
+        registerItem(levelVery, Blocks.AMERANTH_BLOCK);
+    }
+}

--- a/src/main/java/net/linkle/valley/Registry/Mixin/CompostableItems.java
+++ b/src/main/java/net/linkle/valley/Registry/Mixin/CompostableItems.java
@@ -1,0 +1,15 @@
+package net.linkle.valley.Registry.Mixin;
+
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+import net.minecraft.block.ComposterBlock;
+import net.minecraft.item.ItemConvertible;
+
+@Mixin(ComposterBlock.class)
+public interface CompostableItems {
+    @Invoker("registerCompostableItem")
+    static void registerItem(float chance, ItemConvertible item) {
+        throw new AssertionError(); // If this is throwned, then clearly something went wrong.
+    }
+}

--- a/src/main/java/net/linkle/valley/ValleyMain.java
+++ b/src/main/java/net/linkle/valley/ValleyMain.java
@@ -29,6 +29,9 @@ public class ValleyMain implements ModInitializer {
         BlocksCont.initialize();
         Furnaces.ints();
         PotBlock.initialize();
+        
+        // Misc Initializers (Recommended put it after the blocks and items initializers)
+        Compostables.initialize();
 
         //Configured Feature Initializers
         OreConfiguredFeatures.initialize();
@@ -41,6 +44,6 @@ public class ValleyMain implements ModInitializer {
         //WaterPlantConfiguredFeatures.initialize();
 
         //Tells you if this shit actually worked
-        System.out.println("The main mod initialization sections loaded fine somehow™️.");
+        System.out.println("The main mod initialization sections loaded fine somehow.");
     }
 }

--- a/src/main/resources/valley.mixins.json
+++ b/src/main/resources/valley.mixins.json
@@ -4,7 +4,8 @@
   "package": "net.linkle.valley.Registry.Mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
-	"LivingEntityMixin"
+	"LivingEntityMixin",
+	"CompostableItems"
   ],
   "client": [
   ],


### PR DESCRIPTION
Almost all composable items now can be used in Minecraft's composter block. You might have to reorganize the change levels.