### PR TITLE
Add cave and sea patch feature generation.

### DIFF
--- a/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/CaveFeatures.java
+++ b/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/CaveFeatures.java
@@ -1,0 +1,39 @@
+package net.linkle.valley.Registry.Initializers.ConfiguredFeatures;
+
+import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
+import net.fabricmc.fabric.api.biome.v1.BiomeSelectors;
+import net.linkle.valley.ValleyMain;
+import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.Gen.CavePatchConfig;
+import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.Gen.CavePatchFeature;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.registry.BuiltinRegistries;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.gen.GenerationStep;
+import net.minecraft.world.gen.YOffset;
+import net.minecraft.world.gen.decorator.Decorator;
+import net.minecraft.world.gen.decorator.RangeDecoratorConfig;
+import net.minecraft.world.gen.feature.ConfiguredFeature;
+import net.minecraft.world.gen.heightprovider.UniformHeightProvider;
+
+public class CaveFeatures {
+    /** Custom gen feature to spawn stuffs in caves. */
+    private static final CavePatchFeature CAVE_PATCH = new CavePatchFeature();
+
+    private static final ConfiguredFeature<?, ?> GLOW_PATCH_CONFIG = CAVE_PATCH
+            .configure(new CavePatchConfig(Blocks.GLOWSTONE.getDefaultState(), 40, 4, 7));
+
+    @SuppressWarnings("deprecation")
+    public static void initialize() {
+        Registry.register(Registry.FEATURE, new Identifier(ValleyMain.MOD_ID, "cave_patch"), CAVE_PATCH);
+
+        var glowPatch = RegistryKey.of(Registry.CONFIGURED_FEATURE_KEY, new Identifier(ValleyMain.MOD_ID, "glowstone_patch_cave"));
+        var offset = new RangeDecoratorConfig(UniformHeightProvider.create(YOffset.aboveBottom(5), YOffset.fixed(42))); // 42 is maximum height can spawn.
+        var spread = Decorator.RANGE.configure(offset).spreadHorizontally().applyChance(1);
+
+        Registry.register(BuiltinRegistries.CONFIGURED_FEATURE, glowPatch.getValue(), GLOW_PATCH_CONFIG.decorate(spread));
+
+        BiomeModifications.addFeature(BiomeSelectors.foundInOverworld(), GenerationStep.Feature.UNDERGROUND_DECORATION, glowPatch);
+    }
+}

--- a/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/Gen/CavePatchConfig.java
+++ b/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/Gen/CavePatchConfig.java
@@ -1,0 +1,51 @@
+package net.linkle.valley.Registry.Initializers.ConfiguredFeatures.Gen;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.intprovider.ConstantIntProvider;
+import net.minecraft.util.math.intprovider.IntProvider;
+import net.minecraft.world.gen.decorator.DecoratorConfig;
+import net.minecraft.world.gen.feature.FeatureConfig;
+import net.minecraft.world.gen.stateprovider.BlockStateProvider;
+import net.minecraft.world.gen.stateprovider.SimpleBlockStateProvider;
+
+/**
+ * The <code>tries</code> is amount of blocks can spawn in patch, it's better to
+ * set it high value. The <code>size</code> is the size of the patch, and height
+ * is how tall the patch can spawn in (basically a bounding box to spawn in).
+ */
+public record CavePatchConfig(BlockStateProvider state, IntProvider tries, IntProvider height, IntProvider size)
+        implements FeatureConfig, DecoratorConfig {
+
+    public static final Codec<CavePatchConfig> CODEC = RecordCodecBuilder.create(instance -> instance
+            .group(BlockStateProvider.TYPE_CODEC.fieldOf("state").forGetter(CavePatchConfig::state),
+             IntProvider.VALUE_CODEC.fieldOf("tries").forGetter(CavePatchConfig::tries),
+             IntProvider.VALUE_CODEC.fieldOf("height").forGetter(CavePatchConfig::height),
+             IntProvider.VALUE_CODEC.fieldOf("size").forGetter(CavePatchConfig::size))
+            .apply(instance, instance.stable(CavePatchConfig::new)));
+
+    public CavePatchConfig(BlockState state, int tries, int height, int size) {
+        this(new SimpleBlockStateProvider(state), ConstantIntProvider.create(tries), height, size);
+    }
+
+    public CavePatchConfig(BlockState state, IntProvider tries, int height, int size) {
+        this(new SimpleBlockStateProvider(state), tries, height, size);
+    }
+
+    public CavePatchConfig(BlockStateProvider state, int tries, int height, int size) {
+        this(state, ConstantIntProvider.create(tries), height, size);
+    }
+
+    public CavePatchConfig(BlockStateProvider state, IntProvider tries, int height, int size) {
+        this(state, tries, ConstantIntProvider.create(height), ConstantIntProvider.create(size));
+    }
+
+    public CavePatchConfig(BlockStateProvider state, IntProvider tries, IntProvider height, IntProvider size) {
+        this.state = state;
+        this.tries = tries;
+        this.height = height;
+        this.size = size;
+    }
+}

--- a/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/Gen/CavePatchFeature.java
+++ b/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/Gen/CavePatchFeature.java
@@ -1,0 +1,43 @@
+package net.linkle.valley.Registry.Initializers.ConfiguredFeatures.Gen;
+
+import net.minecraft.block.Block;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.feature.util.FeatureContext;
+
+public class CavePatchFeature extends Feature<CavePatchConfig> {
+
+    public CavePatchFeature() {
+        super(CavePatchConfig.CODEC);
+    }
+
+    public boolean generate(FeatureContext<CavePatchConfig> context) {
+        var config = context.getConfig();
+        var random = context.getRandom();
+        var origin = context.getOrigin();
+        var world = context.getWorld();
+        var state = config.state().getBlockState(random, origin);
+        var mutable = new BlockPos.Mutable();
+
+        int height = config.height().get(random);
+        int size = config.size().get(random);
+        int tries = config.tries().get(random);
+        int spawned = 0;
+
+        for (int i = 0; i < tries; ++i) {
+            int xOffset = random.nextInt(size) - random.nextInt(size);
+            int yOffset = random.nextInt(height) - random.nextInt(height);
+            int zOffset = random.nextInt(size) - random.nextInt(size);
+            mutable.set(origin, xOffset, yOffset, zOffset);
+
+            var surface = mutable.down();
+            var surState = world.getBlockState(surface);
+            if (surState.isOpaque() && world.isAir(mutable) && state.canPlaceAt(world, mutable)) {
+                world.setBlockState(mutable, state, Block.NOTIFY_LISTENERS);
+                ++spawned;
+            }
+        }
+
+        return spawned > 0;
+    }
+}

--- a/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/Gen/SeaPatchConfig.java
+++ b/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/Gen/SeaPatchConfig.java
@@ -1,0 +1,48 @@
+package net.linkle.valley.Registry.Initializers.ConfiguredFeatures.Gen;
+
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+
+import net.minecraft.block.BlockState;
+import net.minecraft.util.math.intprovider.ConstantIntProvider;
+import net.minecraft.util.math.intprovider.IntProvider;
+import net.minecraft.world.gen.decorator.DecoratorConfig;
+import net.minecraft.world.gen.feature.FeatureConfig;
+import net.minecraft.world.gen.stateprovider.BlockStateProvider;
+import net.minecraft.world.gen.stateprovider.SimpleBlockStateProvider;
+
+/**
+ * The <code>count</code> is amount of blocks can spawn in patch. The
+ * <code>size</code> is the size of the patch.
+ */
+public record SeaPatchConfig(BlockStateProvider state, IntProvider count, IntProvider size)
+        implements FeatureConfig, DecoratorConfig {
+
+    public static final Codec<SeaPatchConfig> CODEC = RecordCodecBuilder.create(instance -> instance
+            .group(BlockStateProvider.TYPE_CODEC.fieldOf("state").forGetter(SeaPatchConfig::state),
+             IntProvider.VALUE_CODEC.fieldOf("count").forGetter(SeaPatchConfig::count),
+             IntProvider.VALUE_CODEC.fieldOf("size").forGetter(SeaPatchConfig::size))
+            .apply(instance, instance.stable(SeaPatchConfig::new)));
+
+    public SeaPatchConfig(BlockState state, int count, int size) {
+        this(new SimpleBlockStateProvider(state), ConstantIntProvider.create(count), size);
+    }
+
+    public SeaPatchConfig(BlockState state, IntProvider count, int size) {
+        this(new SimpleBlockStateProvider(state), count, size);
+    }
+
+    public SeaPatchConfig(BlockStateProvider state, int count, int size) {
+        this(state, ConstantIntProvider.create(count), size);
+    }
+
+    public SeaPatchConfig(BlockStateProvider state, IntProvider count, int size) {
+        this(state, count, ConstantIntProvider.create(size));
+    }
+
+    public SeaPatchConfig(BlockStateProvider state, IntProvider count, IntProvider size) {
+        this.state = state;
+        this.count = count;
+        this.size = size;
+    }
+}

--- a/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/Gen/SeaPatchFeature.java
+++ b/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/Gen/SeaPatchFeature.java
@@ -1,0 +1,39 @@
+package net.linkle.valley.Registry.Initializers.ConfiguredFeatures.Gen;
+
+import net.minecraft.block.Block;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.Heightmap.Type;
+import net.minecraft.world.gen.feature.Feature;
+import net.minecraft.world.gen.feature.util.FeatureContext;
+
+public class SeaPatchFeature extends Feature<SeaPatchConfig> {
+
+    public SeaPatchFeature() {
+        super(SeaPatchConfig.CODEC);
+    }
+
+    public boolean generate(FeatureContext<SeaPatchConfig> context) {
+        int spawned = 0;
+        var random = context.getRandom();
+        var world = context.getWorld();
+        var origin = context.getOrigin();
+        var stateProvider = context.getConfig().state();
+        int size = context.getConfig().size().get(random);
+        int loops = context.getConfig().count().get(random);
+
+        for (int i = 0; i < loops; ++i) {
+            int xPos = random.nextInt(size) - random.nextInt(size);
+            int zPos = random.nextInt(size) - random.nextInt(size);
+            int n = world.getTopY(Type.OCEAN_FLOOR, origin.getX() + xPos, origin.getZ() + xPos);
+            var blockPos = new BlockPos(origin.getX() + zPos, n, origin.getZ() + xPos);
+            var blockState = stateProvider.getBlockState(random, blockPos);
+            if (world.getBlockState(blockPos).isOf(Blocks.WATER) && blockState.canPlaceAt(world, blockPos)) {
+                world.setBlockState(blockPos, blockState, Block.NOTIFY_LISTENERS);
+                ++spawned;
+            }
+        }
+
+        return spawned > 0;
+    }
+}

--- a/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/OceanFeatures.java
+++ b/src/main/java/net/linkle/valley/Registry/Initializers/ConfiguredFeatures/OceanFeatures.java
@@ -1,0 +1,43 @@
+package net.linkle.valley.Registry.Initializers.ConfiguredFeatures;
+
+import net.fabricmc.fabric.api.biome.v1.BiomeModifications;
+import net.fabricmc.fabric.api.biome.v1.BiomeSelectionContext;
+import net.linkle.valley.ValleyMain;
+import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.Gen.SeaPatchConfig;
+import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.Gen.SeaPatchFeature;
+import net.minecraft.block.Blocks;
+import net.minecraft.util.Identifier;
+import net.minecraft.util.math.intprovider.UniformIntProvider;
+import net.minecraft.util.registry.BuiltinRegistries;
+import net.minecraft.util.registry.Registry;
+import net.minecraft.util.registry.RegistryKey;
+import net.minecraft.world.Heightmap;
+import net.minecraft.world.biome.Biome;
+import net.minecraft.world.gen.GenerationStep;
+import net.minecraft.world.gen.decorator.Decorator;
+import net.minecraft.world.gen.decorator.HeightmapDecoratorConfig;
+import net.minecraft.world.gen.feature.ConfiguredFeature;
+
+@SuppressWarnings("deprecation")
+public class OceanFeatures {
+    /** Custom gen feature to spawn stuffs in ocean. */
+    private static final SeaPatchFeature SEA_PATCH = new SeaPatchFeature();
+
+    private static final ConfiguredFeature<?, ?> GLOW_PATCH_CONFIG = SEA_PATCH
+            .configure(new SeaPatchConfig(Blocks.GLOWSTONE.getDefaultState(), UniformIntProvider.create(4, 6), 8));
+
+    public static void initialize() {
+        Registry.register(Registry.FEATURE, new Identifier(ValleyMain.MOD_ID, "sea_patch"), SEA_PATCH);
+
+        var glowPatch = RegistryKey.of(Registry.CONFIGURED_FEATURE_KEY, new Identifier(ValleyMain.MOD_ID, "glowstone_patch"));
+        var oceanFloor = Decorator.HEIGHTMAP.configure(new HeightmapDecoratorConfig(Heightmap.Type.OCEAN_FLOOR_WG)).spreadHorizontally();
+
+        Registry.register(BuiltinRegistries.CONFIGURED_FEATURE, glowPatch.getValue(), GLOW_PATCH_CONFIG.decorate(oceanFloor).applyChance(5));
+
+        BiomeModifications.addFeature(OceanFeatures::oceanOnly, GenerationStep.Feature.VEGETAL_DECORATION, glowPatch);
+    }
+
+    private static boolean oceanOnly(BiomeSelectionContext context) {
+        return context.getBiome().getCategory() == Biome.Category.OCEAN;
+    }
+}

--- a/src/main/java/net/linkle/valley/Registry/Initializers/Entities.java
+++ b/src/main/java/net/linkle/valley/Registry/Initializers/Entities.java
@@ -49,11 +49,7 @@ public class Entities {
     }
 
     public static void initializeClient() {
-        EntityRendererRegistry.register(BEAR, (context) -> {
-            return new BearEntityRenderer(context);
-        });
-        EntityRendererRegistry.register(DUCK, (context) -> {
-            return new DuckEntityRenderer(context);
-        });
+        EntityRendererRegistry.register(BEAR, BearEntityRenderer::new);
+        EntityRendererRegistry.register(DUCK, DuckEntityRenderer::new);
     }
 }

--- a/src/main/java/net/linkle/valley/ValleyMain.java
+++ b/src/main/java/net/linkle/valley/ValleyMain.java
@@ -3,6 +3,7 @@ package net.linkle.valley;
 import net.fabricmc.api.ModInitializer;
 import net.linkle.valley.Registry.Blocks.Decorations.Furnaces.Furnaces;
 import net.linkle.valley.Registry.Initializers.*;
+import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.CaveFeatures;
 import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.OreConfiguredFeatures;
 import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.OverworldPlantConfiguredFeatures;
 import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.Trees;
@@ -38,6 +39,7 @@ public class ValleyMain implements ModInitializer {
         //Configured Feature Initializers
         OreConfiguredFeatures.initialize();
         OverworldPlantConfiguredFeatures.initialize();
+        CaveFeatures.initialize();
         Trees.ints();
 
         //Future Updates ;)

--- a/src/main/java/net/linkle/valley/ValleyMain.java
+++ b/src/main/java/net/linkle/valley/ValleyMain.java
@@ -4,6 +4,7 @@ import net.fabricmc.api.ModInitializer;
 import net.linkle.valley.Registry.Blocks.Decorations.Furnaces.Furnaces;
 import net.linkle.valley.Registry.Initializers.*;
 import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.CaveFeatures;
+import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.OceanFeatures;
 import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.OreConfiguredFeatures;
 import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.OverworldPlantConfiguredFeatures;
 import net.linkle.valley.Registry.Initializers.ConfiguredFeatures.Trees;
@@ -40,6 +41,7 @@ public class ValleyMain implements ModInitializer {
         OreConfiguredFeatures.initialize();
         OverworldPlantConfiguredFeatures.initialize();
         CaveFeatures.initialize();
+        OceanFeatures.initialize();
         Trees.ints();
 
         //Future Updates ;)


### PR DESCRIPTION
Glowstone blocks will be spawned in the cave and ocean. You can disable it or add your features like cave plants or shells into the world's gen.